### PR TITLE
Delete Nodes via Kubernetes API

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -22,6 +22,7 @@ type KubernetesClient interface {
 	DrainNode(string, int) error
 	DrainKubeDNSFromNode(string, int) error
 	GetNode(string) (*apiv1.Node, error)
+	DeleteNode(string) error
 	GetPreemptibleNodes() (*apiv1.NodeList, error)
 	GetProjectIdAndZoneFromNode(string) (string, string, error)
 	SetNodeAnnotation(string, string, string) error
@@ -92,6 +93,11 @@ func (k *Kubernetes) GetPreemptibleNodes() (nodes *apiv1.NodeList, err error) {
 // GetNode return the node object from given name
 func (k *Kubernetes) GetNode(name string) (node *apiv1.Node, err error) {
 	node, err = k.Client.CoreV1().GetNode(context.Background(), name)
+	return
+}
+
+func (k *Kubernetes) DeleteNode(name string) (err error) {
+	err = k.Client.CoreV1().DeleteNode(context.Background(), name)
 	return
 }
 

--- a/main.go
+++ b/main.go
@@ -303,6 +303,17 @@ func processNode(k KubernetesClient, node *apiv1.Node) (err error) {
 			return
 		}
 
+		// delete node from kubernetes cluster
+		err = k.DeleteNode(*node.Metadata.Name)
+
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("host", *node.Metadata.Name).
+				Msg("Error deleting node")
+				return
+		}
+
 		// delete gcloud instance
 		err = gcloud.DeleteNode(*node.Metadata.Name)
 

--- a/main_test.go
+++ b/main_test.go
@@ -35,6 +35,10 @@ func (k *FakeKubernetes) GetNode(name string) (*apiv1.Node, error) {
 	return &apiv1.Node{}, nil
 }
 
+func (k *FakeKubernetes) DeleteNode(name string) error {
+	return nil
+}
+
 func (k *FakeKubernetes) SetNodeAnnotation(name string, key string, value string) error {
 	return nil
 }


### PR DESCRIPTION
Hey,

somehow my gke nodes return with the same name after deletion. 
Because of this, the returning node was still marked as not schedulable in my cluster. Eventually, all of my preemptible nodes would become unusuable. 

In order to prevent this, I trigger a DeleteNode call on Kubernetes which removes the node from the master correctly. 

This works just fine in my GKE setup. What do you think about this?

Best,
Johannes