### PR TITLE
Bump chart version to 1.17

### DIFF
--- a/chart/estafette-gke-preemptible-killer/Chart.yaml
+++ b/chart/estafette-gke-preemptible-killer/Chart.yaml
@@ -1,5 +1,5 @@
 name: estafette-gke-preemptible-killer
-version: 1.1.15
+version: 1.1.17
 description: A Kubernetes controller that loops through a given preemptibles node pool and kills a node before the regular 24h life time of a preemptible VM
 home: https://estafette.io/
 sources:


### PR DESCRIPTION
This is the latest version according to Dockerhub.

PS: We like project very much but things like lack of releases at Github, not up-to-date chart etc. makes us consider forking our own version and maintain it. What's your vision about this project in general?