### PR TITLE
[🐛 FIX] -b|--blacklist-hours

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,9 @@ var (
 func init() {
 	// Metrics have to be registered to be exposed:
 	prometheus.MustRegister(nodeTotals)
+
+	whitelistInstance.blacklist = *blacklist
+	whitelistInstance.whitelist = *whitelist
 }
 
 func main() {

--- a/whitelist.go
+++ b/whitelist.go
@@ -154,13 +154,14 @@ func (this *WhitelistInstance) processHours(input string, direction string) {
 	}
 
 	// Split in intervals.
-	intervals := strings.Split(input, ", ")
+	input = strings.Replace(input, " ", "", -1)
+	intervals := strings.Split(input, ",")
 	for _, timeInterval := range intervals {
-		times := strings.Split(timeInterval, " - ")
+		times := strings.Split(timeInterval, "-")
 
 		// Check format.
 		if len(times) != 2 {
-			panic(fmt.Sprintf("processHours(): interval '%v' should be of the form `09:00 - 12:00`", timeInterval))
+			panic(fmt.Sprintf("processHours(): interval '%v' should be of the form `09:00 - 11:00[, 21:00 - 23:00[, ...]]`", timeInterval))
 		}
 
 		// Start time

--- a/whitelist_test.go
+++ b/whitelist_test.go
@@ -90,11 +90,11 @@ func TestProcessHours(t *testing.T) {
 	i.initialize()
 
 	// Check that argument parsing works.
-	*whitelist = "00:00 - 04:00, 08:00 - 12:00, 16:00 - 20:00"
-	*blacklist = "01:00 - 02:00, 06:00 - 14:00, 15:00 - 17:00"
+	i.whitelist = "00:00 - 04:00, 08:00 - 12:00, 16:00 - 20:00"
+	i.blacklist = "01:00 - 02:00, 06:00 - 14:00, 15:00 - 17:00"
 	i.parseArguments()
 	if i.whitelistSecondCount != 21600 {
-		t.Errorf("Expected 3600 seconds, got '%v'", i.whitelistSecondCount)
+		t.Errorf("Expected 21600 seconds, got '%v'", i.whitelistSecondCount)
 	}
 }
 


### PR DESCRIPTION
https://github.com/estafette/estafette-gke-preemptible-killer/pull/24#issuecomment-504658046

Previously, when specifying blacklists, you would only get a 50% chance reduction of getting that interval hit instead of a 100% chance reduction. That was a bug and this fixes it.
Also simplified the logic a lot.