### PR TITLE
[🐛 FIX] whitelists were being ignored on two accounts:

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,9 +86,6 @@ var (
 func init() {
 	// Metrics have to be registered to be exposed:
 	prometheus.MustRegister(nodeTotals)
-
-	whitelistInstance.blacklist = *blacklist
-	whitelistInstance.whitelist = *whitelist
 }
 
 func main() {
@@ -96,6 +93,8 @@ func main() {
 
 	initializeLogger()
 
+	whitelistInstance.blacklist = *blacklist
+	whitelistInstance.whitelist = *whitelist
 	whitelistInstance.parseArguments()
 
 	kubernetes, err := NewKubernetesClient(os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"),


### PR DESCRIPTION
1. They were initialized before arguments were parsed
2. An offset which decided if the kill should happen today or tomorrow was being misused which made it overflow which triggered an emergency fallback to no whitelists

It always got stuck in number 1, but if it were ever solved, the whitelists would have still been ignored by number 2.

Fixes #34 

Now works reliably as I have tested more robustly with the script in #35.