### PR TITLE
[📦 NEW] label filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can either use environment variables or flags to configure the following set
 | ---------------------- | ------------------------ | -------- | -----------------------------------------------------------------
 | BLACKLIST_HOURS        | --blacklist-hours (-b)   |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is NOT allowed
 | DRAIN_TIMEOUT          | --drain-timeout          | 300      | Max time in second to wait before deleting a node
-| FILTERS                | --filters (-f)           |          | Label filters in the form 9of `key1: value1[, value2[, ...]][; key2: value3[, value4[, ...]], ...]`
+| FILTERS                | --filters (-f)           |          | Label filters in the form of `key1: value1[, value2[, ...]][; key2: value3[, value4[, ...]], ...]`
 | INTERVAL               | --interval (-i)          | 600      | Time in second to wait between each node check
 | KUBECONFIG             | --kubeconfig             |          | Provide the path to the kube config path, usually located in ~/.kube/config. This argument is only needed if you're running the killer outside of your k8s cluster
 | METRICS_LISTEN_ADDRESS | --metrics-listen-address | :9001    | The address to listen on for Prometheus metrics requests

--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ You can either use environment variables or flags to configure the following set
 
 | Environment variable   | Flag                     | Default  | Description
 | ---------------------- | ------------------------ | -------- | -----------------------------------------------------------------
-| BLACKLIST_HOURS        | --blacklist-hours        |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is NOT allowed
+| BLACKLIST_HOURS        | --blacklist-hours (-b)   |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is NOT allowed
 | DRAIN_TIMEOUT          | --drain-timeout          | 300      | Max time in second to wait before deleting a node
+| FILTERS                | --filters (-f)           |          | Label filters in the form 9of `key1: value1[, value2[, ...]][; key2: value3[, value4[, ...]], ...]`
 | INTERVAL               | --interval (-i)          | 600      | Time in second to wait between each node check
 | KUBECONFIG             | --kubeconfig             |          | Provide the path to the kube config path, usually located in ~/.kube/config. This argument is only needed if you're running the killer outside of your k8s cluster
 | METRICS_LISTEN_ADDRESS | --metrics-listen-address | :9001    | The address to listen on for Prometheus metrics requests
 | METRICS_PATH           | --metrics-path           | /metrics | The path to listen for Prometheus metrics requests
-| WHITELIST_HOURS        | --whitelist-hours        |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is allowed and preferred
+| WHITELIST_HOURS        | --whitelist-hours (-w)   |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is allowed and preferred
 
 ### Create a Google Service Account
 

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -23,7 +23,7 @@ type KubernetesClient interface {
 	DrainKubeDNSFromNode(string, int) error
 	GetNode(string) (*apiv1.Node, error)
 	DeleteNode(string) error
-	GetPreemptibleNodes() (*apiv1.NodeList, error)
+	GetPreemptibleNodes(map[string]string) (*apiv1.NodeList, error)
 	GetProjectIdAndZoneFromNode(string) (string, string, error)
 	SetNodeAnnotation(string, string, string) error
 	SetUnschedulableState(string, bool) error
@@ -83,9 +83,13 @@ func (k *Kubernetes) GetProjectIdAndZoneFromNode(name string) (projectId string,
 }
 
 // GetPreemptibleNodes return a list of preemptible node
-func (k *Kubernetes) GetPreemptibleNodes() (nodes *apiv1.NodeList, err error) {
+func (k *Kubernetes) GetPreemptibleNodes(filters map[string]string) (nodes *apiv1.NodeList, err error) {
 	labels := new(k8s.LabelSelector)
 	labels.Eq("cloud.google.com/gke-preemptible", "true")
+	for key, value := range filters {
+		values := strings.Split(value, ",")
+		labels.In(key, values...)
+	}
 	nodes, err = k.Client.CoreV1().ListNodes(context.Background(), labels.Selector())
 	return
 }

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ var (
 			Envar("DRAIN_TIMEOUT").
 			Default("300").
 			Int()
-	filters = kingpin.Flag("filters", "label filters in the form of `key1: value1[, value2[, ...]][; key2: value3[, value4[, ...]]]`").
+	filters = kingpin.Flag("filters", "Label filters in the form of `key1: value1[, value2[, ...]][; key2: value3[, value4[, ...]], ...]`").
 		Default("").
 		Envar("FILTERS").
 		Short('f').


### PR DESCRIPTION
Users might want to filter preemptible nodes by certain labels.

```
estafette-gke-preemptible-killer -f "cloud.google.com/gke-preemptible: \"true\"; kubernetes.io/hostname: kind-worker2, kind-worker3"
```
filters for all nodes that have gke-preemptible set to `"true"` and hostname set to either `kind-worker2` or `kind-worker3`.

Tested with:
```
./scripts/all-in-one-test -f "cloud.google.com/gke-preemptible: \"true\"; kubernetes.io/hostname: kind-worker2"
```