### PR TITLE
Add missing node permissions to the service account

### DIFF
--- a/helm/estafette-gke-preemptible-killer/templates/clusterrole.yaml
+++ b/helm/estafette-gke-preemptible-killer/templates/clusterrole.yaml
@@ -27,4 +27,12 @@ rules:
   - create
   - get
   - update
+- apiGroups: [""] # "" indicates the core/v1 API group
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - delete
+  - update
 {{- end -}}


### PR DESCRIPTION
This PR is adding required permissions to service account.

I am not sure if this is the complete list though. Why does this app need access to secrets and events? It also drains kube-dns from the node, thus it requires Pod related permissions also I think.