### PR TITLE
fix incorrect clusterrole

### DIFF
--- a/helm/estafette-gke-preemptible-killer/templates/clusterrole.yaml
+++ b/helm/estafette-gke-preemptible-killer/templates/clusterrole.yaml
@@ -8,23 +8,18 @@ metadata:
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources:
-  - secrets
+  - nodes
   verbs:
-  - create
   - get
   - list
+  - patch
   - update
-  - watch
+  - delete
 - apiGroups: [""] # "" indicates the core API group
   resources:
-  - namespaces
+  - pods
   verbs:
-  - list
-- apiGroups: [""] # "" indicates the core/v1 API group
-  resources:
-  - events
-  verbs:
-  - create
+  - delete
   - get
-  - update
+  - list
 {{- end -}}


### PR DESCRIPTION
Restores the ClusterRole to it's original version at https://github.com/estafette/estafette-gke-preemptible-killer/pull/43/files#diff-0d3db36ca60f7f38c816d42593594ae1 which was incorrectly set when creating the official Helm chart.

Fixes #55 
Fixes #52 