### PR TITLE
[👌 IMPROVE] test script

### DIFF
--- a/scripts/all-in-one-test
+++ b/scripts/all-in-one-test
@@ -5,9 +5,14 @@ set -euo pipefail
 # Get script path.
 script_path=$(dirname "$(readlink -f "${0}")")
 
+# Cleanup
+for t in HUP INT QUIT KILL TERM EXIT; do
+  trap "rm -f '${script_path}/a.log' '${script_path}/a.yaml' '${script_path}/kube-config.yaml'" "${t}"
+done
+
 # Create cluster using YAML provided in quick start guide of kind.
 kind create cluster --config "${script_path}/kind-example-config.yaml" || true
-export KUBECONFIG=$(kind get kubeconfig-path --name='kind')
+kind get kubeconfig > "${script_path}/kube-config.yaml"
 
 # For all the nodes, export it's configuration to YAML, add gke-preemptible
 # annotation, delete any previous killer state, then replace the configuration.
@@ -18,12 +23,12 @@ for n in '' {2..3}; do
   kubectl replace -f "${script_path}/a.yaml"
 done
 
-# Cleanup
-rm -f "${script_path}/a.yaml"
-
 # Run estafette-gke-preemptible-killer with all the arguments provided to this
 # script.
-timeout 5s "${script_path}/../estafette-gke-preemptible-killer" "${@}" || true
+"${script_path}/../estafette-gke-preemptible-killer" "${@}" --kubeconfig "${script_path}/kube-config.yaml" | tee "${script_path}/a.log" &
+pid=${!}
+"${script_path}/wait-for-line-in-file" 'Sleeping for' "${script_path}/a.log"
+kill ${pid}
 
 # For all the nodes report their CreationTimestamp and their
 # gke-preemptible-killer-state.

--- a/scripts/all-in-one-test
+++ b/scripts/all-in-one-test
@@ -7,7 +7,7 @@ script_path=$(dirname "$(readlink -f "${0}")")
 
 # Cleanup
 for t in HUP INT QUIT KILL TERM EXIT; do
-  trap "rm -f '${script_path}/a.log' '${script_path}/a.yaml' '${script_path}/kube-config.yaml'" "${t}"
+  trap "rm -f '${script_path}/a.log' '${script_path}/a.yaml' '${script_path}/kube-config.yaml' '${script_path}/pid'" "${t}"
 done
 
 # Create cluster using YAML provided in quick start guide of kind.
@@ -25,10 +25,9 @@ done
 
 # Run estafette-gke-preemptible-killer with all the arguments provided to this
 # script.
-"${script_path}/../estafette-gke-preemptible-killer" "${@}" --kubeconfig "${script_path}/kube-config.yaml" | tee "${script_path}/a.log" &
-pid=${!}
+( "${script_path}/../estafette-gke-preemptible-killer" "${@}" --kubeconfig "${script_path}/kube-config.yaml" & echo ${!} >&3 ) 3>"${script_path}/pid" | tee "${script_path}/a.log" &
 "${script_path}/wait-for-line-in-file" 'Sleeping for' "${script_path}/a.log"
-kill ${pid}
+kill $(<"${script_path}/pid")
 
 # For all the nodes report their CreationTimestamp and their
 # gke-preemptible-killer-state.

--- a/scripts/all-in-one-test
+++ b/scripts/all-in-one-test
@@ -23,9 +23,15 @@ for n in '' {2..3}; do
   kubectl replace -f "${script_path}/a.yaml"
 done
 
+killer="${script_path}/../estafette-gke-preemptible-killer"
+if ! test -f "${killer}"; then
+  printf "%s doesn't exist. Build first.\\n" "${killer}"
+  exit 1
+fi
+
 # Run estafette-gke-preemptible-killer with all the arguments provided to this
 # script.
-( "${script_path}/../estafette-gke-preemptible-killer" "${@}" --kubeconfig "${script_path}/kube-config.yaml" & echo ${!} >&3 ) 3>"${script_path}/pid" | tee "${script_path}/a.log" &
+( "${killer}" "${@}" --kubeconfig "${script_path}/kube-config.yaml" & echo ${!} >&3 ) 3>"${script_path}/pid" | tee "${script_path}/a.log" &
 "${script_path}/wait-for-line-in-file" 'Sleeping for' "${script_path}/a.log"
 kill $(<"${script_path}/pid")
 

--- a/scripts/kind-example-config.yaml
+++ b/scripts/kind-example-config.yaml
@@ -1,17 +1,16 @@
 # this config file contains all config fields with comments
+# NOTE: this is not a particularly useful config file
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 # patch the generated kubeadm config with some extra settings
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta2
-  kind: ClusterConfiguration
-  metadata:
-    name: config
-  networking:
-    serviceSubnet: 10.0.0.0/16
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+  evictionHard:
+    nodefs.available: "0%"
 # patch it further using a JSON 6902 patch
-kubeadmConfigPatchesJson6902:
+kubeadmConfigPatchesJSON6902:
 - group: kubeadm.k8s.io
   version: v1beta2
   kind: ClusterConfiguration

--- a/scripts/wait-for-line-in-file
+++ b/scripts/wait-for-line-in-file
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Copyright (C) 2019 Andrei Pavel, andrei.pavel@cti.pub.ro
+# Licensed under the MIT License
+
+# Header
+[[ -z "${ARGUMENTS+x}" ]] && ARGUMENTS="\
+  \$line
+  \$file
+  [\$timeout]
+"
+script_path="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+#------------------------------------------------------------------------------#
+
+function read-offset() {
+  local file
+  file="$(readlink -f "${1}")"
+  file="${file//-/_}"
+  file="${file//./_}"
+  file="${file//\//_}"
+  offset="OFFSET_${file}"
+  printf '%s' "${!offset-1}"
+}
+
+function update-offset() {
+  local file
+  file="$(readlink -f "${1}")"
+  file="${file//-/_}"
+  file="${file//./_}"
+  file="${file//\//_}"
+  read -r "OFFSET_${file}" <<< "${2}"
+}
+
+function update-line-count-for-file() {
+  file="$(readlink -f "${1}")"
+  line_count_in_file="$(wc -l "${file}" | cut -d ' ' -f 1)"
+  update-offset "${file}" "$(( line_count_in_file + 1 ))"
+}
+
+line="$(printf '%q' "${1}")"
+line="${line//\//\\\/}"
+file="$(readlink -f "${2}")"
+timeout="${3-30 seconds}"
+finish="$(date +%s -d "${timeout}")"
+
+# Wait for file to be created.
+while [[ ! -f ${file} ]]; do
+  sleep 1s
+done
+
+while true; do
+  # Check if timeout has passed.
+  if (( "${finish}" < "$(date +%s)" )); then
+    printf "
+ERROR: Timed out after ${timeout} of waiting for line in file:
++- line: ${line}
++- file: ${file}
+
+%s\n" "$(tail "${file}")" >&2
+    exit 1
+  fi
+
+  offset="$(read-offset "${file}")"
+  # Check if we have reached end of file.
+  line_count_in_file="$(wc -l "${file}" | cut -d ' ' -f 1)"
+  if (( offset > line_count_in_file )); then
+    sleep 1s
+    continue
+  fi
+
+  line_number_found="$(sed "${offset},${line_count_in_file}!d;/${line}/!d;=" "${file}" | head -n 1)" || true
+
+  if [[ -z "${line_number_found}" ]]; then
+    # not found
+    update-offset "${file}" "$(( line_count_in_file + 1 ))"
+  else
+    # found
+    update-offset "${file}" "$(( line_number_found + 1 ))"
+    break
+  fi
+done


### PR DESCRIPTION
- kind syntax has changed, make it work with kind version 0.7.0
- rather than cleaning up at the end, use traps to cleanup in case script fails mid-way
- rather than timing out the killer for five seconds and hope it has written the annotations by then, wait for the killer to finish by looking into what it writes to standard output and then send a kill signal to finish the killer which the timeout already did before anyway, there's no compromise there, the script now ends instantaneously from the second run onwards since on the first run it creates the kind cluster