### PR TITLE
[📦 NEW] -m, --minimum-kill-interval 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,17 @@ deleted on GCloud.
 
 You can either use environment variables or flags to configure the following settings:
 
-| Environment variable   | Flag                     | Default  | Description
-| ---------------------- | ------------------------ | -------- | -----------------------------------------------------------------
-| BLACKLIST_HOURS        | --blacklist-hours (-b)   |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is NOT allowed
-| DRAIN_TIMEOUT          | --drain-timeout          | 300      | Max time in second to wait before deleting a node
-| FILTERS                | --filters (-f)           |          | Label filters in the form of `key1: value1[, value2[, ...]][; key2: value3[, value4[, ...]], ...]`
-| INTERVAL               | --interval (-i)          | 600      | Time in second to wait between each node check
-| KUBECONFIG             | --kubeconfig             |          | Provide the path to the kube config path, usually located in ~/.kube/config. This argument is only needed if you're running the killer outside of your k8s cluster
-| METRICS_LISTEN_ADDRESS | --metrics-listen-address | :9001    | The address to listen on for Prometheus metrics requests
-| METRICS_PATH           | --metrics-path           | /metrics | The path to listen for Prometheus metrics requests
-| WHITELIST_HOURS        | --whitelist-hours (-w)   |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is allowed and preferred
+| Environment variable   | Flag                         | Default  | Description
+| ---------------------- | ---------------------------- | -------- | -----------------------------------------------------------------
+| BLACKLIST_HOURS        | --blacklist-hours (-b)       |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is NOT allowed
+| DRAIN_TIMEOUT          | --drain-timeout              | 300      | Max time in second to wait before deleting a node
+| FILTERS                | --filters (-f)               |          | Label filters in the form of `key1: value1[, value2[, ...]][; key2: value3[, value4[, ...]], ...]`
+| INTERVAL               | --interval (-i)              | 600      | Time in second to wait between each node check
+| KUBECONFIG             | --kubeconfig                 |          | Provide the path to the kube config path, usually located in ~/.kube/config. This argument is only needed if you're running the killer outside of your k8s cluster
+| METRICS_LISTEN_ADDRESS | --metrics-listen-address     | :9001    | The address to listen on for Prometheus metrics requests
+| METRICS_PATH           | --metrics-path               | /metrics | The path to listen for Prometheus metrics requests
+| MINIMUM_KILL_INTERVAL  | --minimum-kill-interval (-m) | ""       | Minimum time interval between kills e.g. 13h37m
+| WHITELIST_HOURS        | --whitelist-hours (-w)       |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is allowed and preferred
 
 ### Create a Google Service Account
 

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 	kubeConfigPath = kingpin.Flag("kubeconfig", "Provide the path to the kube config path, usually located in ~/.kube/config. For out of cluster execution").
 			Envar("KUBECONFIG").
 			String()
-	minimumKillInterval = kingpin.Flag("minimum-kill-interval", "minimum time interval between kills e.g. 30m25s").
+	minimumKillInterval = kingpin.Flag("minimum-kill-interval", "Minimum time interval between kills e.g. 13h37m").
 				Envar("MINIMUM_KILL_INTERVAL").
 				Default("").
 				Short('m').
@@ -215,8 +215,6 @@ func getDesiredNodeState(k KubernetesClient, node *apiv1.Node) (state GKEPreempt
 			fmt.Sprintf("%2.0d", s.Minute()) + " - " +
 			fmt.Sprintf("%2.0d", e.Hour()) + ":" +
 			fmt.Sprintf("%2.0d", e.Minute())
-		fmt.Println(expiryDatetime)
-		fmt.Println(interval)
 		whitelistInstance.processHours(interval, "-")
 	}
 	state.ExpiryDatetime = expiryDatetime.Format(time.RFC3339)

--- a/main.go
+++ b/main.go
@@ -211,10 +211,10 @@ func getDesiredNodeState(k KubernetesClient, node *apiv1.Node) (state GKEPreempt
 	if len(*minimumKillInterval) != 0 {
 		s := expiryDatetime.Add(-minimumKillDuration)
 		e := expiryDatetime.Add(minimumKillDuration)
-		interval := fmt.Sprintf("%2.0d", s.Hour()) + ":" +
-			fmt.Sprintf("%2.0d", s.Minute()) + " - " +
-			fmt.Sprintf("%2.0d", e.Hour()) + ":" +
-			fmt.Sprintf("%2.0d", e.Minute())
+		interval := fmt.Sprintf("%2d", s.Hour()) + ":" +
+			fmt.Sprintf("%2d", s.Minute()) + " - " +
+			fmt.Sprintf("%2d", e.Hour()) + ":" +
+			fmt.Sprintf("%2d", e.Minute())
 		whitelistInstance.processHours(interval, "-")
 	}
 	state.ExpiryDatetime = expiryDatetime.Format(time.RFC3339)

--- a/whitelist.go
+++ b/whitelist.go
@@ -20,8 +20,9 @@ const (
 )
 
 var (
-	whitelistStart time.Time
-	whitelistEnd   time.Time
+	whitelistStart           time.Time
+	whitelistEnd             time.Time
+	initialWhitelistInstance WhitelistInstance
 )
 
 func init() {
@@ -68,6 +69,7 @@ func (w *WhitelistInstance) parseArguments() {
 	}
 
 	w.processHours(w.blacklist, "-")
+	initialWhitelistInstance = *w
 }
 
 func (w *WhitelistInstance) isEmpty() bool {

--- a/whitelist.go
+++ b/whitelist.go
@@ -105,7 +105,6 @@ func (w *WhitelistInstance) getExpiryDate(t time.Time, timeToBeAdded time.Durati
 				// This is it, project it back to real time.
 				expiryDatetime = truncatedCreationTime.Add(start.Add(timeToBeAdded).Sub(whitelistStart))
 				// But if expiryDatetime is before creation...
-				fmt.Println("before creation? " + expiryDatetime.String() + " " + t.String())
 				if expiryDatetime.Before(t) {
 					// Simply add 24h.
 					expiryDatetime = expiryDatetime.Add(24 * time.Hour)

--- a/whitelist_test.go
+++ b/whitelist_test.go
@@ -97,37 +97,3 @@ func TestProcessHours(t *testing.T) {
 		t.Errorf("Expected 21600 seconds, got '%v'", i.whitelistSecondCount)
 	}
 }
-
-func TestUpdateWhitelistSecondCount(t *testing.T) {
-	var i WhitelistInstance
-	i.initialize()
-
-	// Check that basic scenario works.
-	i.updateWhitelistSecondCount(a, b)
-	if i.whitelistSecondCount != 3600 {
-		t.Errorf("Expected 3600 seconds, got '%v'", i.whitelistSecondCount)
-	}
-	i.whitelistSecondCount = 0
-
-	// Check that adding a multi-day interval works.
-	i.updateWhitelistSecondCount(b, c)
-	if i.whitelistSecondCount != 10811040 {
-		t.Errorf("Expected 10811040 seconds, got '%v'", i.whitelistSecondCount)
-	}
-	i.whitelistSecondCount = 0
-
-	// Check that adding a zero interval doesn't change second count.
-	i.updateWhitelistSecondCount(a, a)
-	if i.whitelistSecondCount != 0 {
-		t.Errorf("Expected 0 seconds, got '%v'", i.whitelistSecondCount)
-	}
-	i.whitelistSecondCount = 0
-
-	// Check that adding a reverse interval panics.
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic when adding '%v - %v'", b, a)
-		}
-	}()
-	i.updateWhitelistSecondCount(b, a)
-}


### PR DESCRIPTION
Implements #67 

It uses the time intervals introduced with the whitelisting feature. The way it works is once a kill time has been decided, an amount of time between the minimum kill interval before and after the decided kill time is blacklisted. This is required so that the two features can work together and from that point of view, the solution is quite elegant in my opinion. Note that these time intervals are used even when whitelists or blacklists are not used so whitelists don't have to be used in order for minimum kill interval to work.

However, it does still have one quirk. It will work as intended on the first sweep. But when a node is selected the second time for scheduling and from that time onwards, the respective blacklists will extraneously munch away from the active interval in which kill times could have been decided, eventually the interval reaching zero, moment at which it will panic saying that `minimum kill interval is too high`, even though that's not the case. I haven't tested this, I only know this theoretically.

The fix might be to schedule a removal of the blacklist interval when the node has died. But since the node might die from external factors (correct me if I'm wrong), this is not the best solution.

Otherwise, the best fix might be to look at all the nodes like @JorritSalverda said in the issue https://github.com/estafette/estafette-gke-preemptible-killer/issues/67#issuecomment-591350684.

I'm unavailable for a few days, I'll sleep on it, I think this pull request is still viable for integration in master as is.