### PR TITLE
Adding capability to byo own secret

### DIFF
--- a/helm/estafette-gke-preemptible-killer/Chart.yaml
+++ b/helm/estafette-gke-preemptible-killer/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Kubernetes controller to spread preemption for preemtible VMs in GKE to avoid mass deletion after 24 hours
 name: estafette-gke-preemptible-killer
-version: 0.1.0
+version: 0.1.1
 home: https://helm.estafette.io
 icon: https://helm.estafette.io/icon.png

--- a/helm/estafette-gke-preemptible-killer/templates/deployment.yaml
+++ b/helm/estafette-gke-preemptible-killer/templates/deployment.yaml
@@ -80,10 +80,20 @@ spec:
           {{- end }}
       terminationGracePeriodSeconds: 300
       {{- if not .Values.secret.workloadIdentityServiceAccount }}
+      {{- if .Values.secret.googleServiceAccountSecret.name}}
+      volumes:
+      - name: gcp-service-account-secret
+        secret:
+          secretName: {{ .Values.secret.googleServiceAccountSecret.name }}
+          items:
+          - key: {{ .Values.secret.googleServiceAccountSecret.key }}
+            path: service-account-key.json
+      {{- else }}
       volumes:
       - name: gcp-service-account-secret
         secret:
           secretName: {{ include "estafette-gke-preemptible-killer.fullname" . }}
+      {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/estafette-gke-preemptible-killer/templates/secret.yaml
+++ b/helm/estafette-gke-preemptible-killer/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secret.workloadIdentityServiceAccount }}
+{{- if and (not .Values.secret.workloadIdentityServiceAccount) (not .Values.secret.googleServiceAccountSecret.name)}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/estafette-gke-preemptible-killer/values.yaml
+++ b/helm/estafette-gke-preemptible-killer/values.yaml
@@ -25,6 +25,13 @@ secret:
   # sets a json keyfile for a gcp service account
   googleServiceAccountKeyfileJson: '{"type": "service_account"}'
 
+  # provide your own secret with the gcp service account json
+  googleServiceAccountSecret:
+    # name of secret
+    name: ""
+    # key of secret
+    key: ""
+
 # the following log formats are available: plaintext, console, json, stackdriver, v3 (see https://github.com/estafette/estafette-foundation for more info)
 logFormat: plaintext
 


### PR DESCRIPTION
This PR adds the capability to define your own Kube secret to use. This way you don't need to specify any API keys in your values file.