### PR TITLE
[helm] monitoring add servicemonitor option

### DIFF
--- a/helm/estafette-gke-preemptible-killer/templates/deployment.yaml
+++ b/helm/estafette-gke-preemptible-killer/templates/deployment.yaml
@@ -25,8 +25,10 @@ spec:
         {{ $key }}: {{ $value }}
         {{- end }}
       annotations:
+        {{- if and .Values.prometheus.enabled (not .Values.prometheus.servicemonitor.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "9101"
+        {{- end }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/helm/estafette-gke-preemptible-killer/templates/servicemonitor.yaml
+++ b/helm/estafette-gke-preemptible-killer/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "estafette-gke-preemptible-killer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "estafette-gke-preemptible-killer.labels" . | indent 4 }}
+    app.kubernetes.io/name: {{ include "estafette-gke-preemptible-killer.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    prometheus: {{ .Values.prometheus.servicemonitor.prometheusInstance }}
+{{- if .Values.prometheus.servicemonitor.labels }}
+{{ toYaml .Values.prometheus.servicemonitor.labels | indent 4}}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "estafette-gke-preemptible-killer.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
+    path: {{ .Values.prometheus.servicemonitor.path }}
+    interval: {{ .Values.prometheus.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
+{{- end }}

--- a/helm/estafette-gke-preemptible-killer/values.yaml
+++ b/helm/estafette-gke-preemptible-killer/values.yaml
@@ -100,3 +100,16 @@ extraLabels: {}
 
 # use to add extra labels to podspec for getting their values in prometheus
 extraPodLabels: {}
+
+# prometheus monitoring
+prometheus:
+  enabled: true
+  servicemonitor:
+    # if service monitor is enabled pormetheus scraping annotions are removed
+    enabled: false
+    prometheusInstance: default
+    targetPort: 9101
+    path: /metrics
+    interval: 60s
+    scrapeTimeout: 30s
+    labels: {}


### PR DESCRIPTION
Hello,

I made a change to the helm chart to be able to use the servicemonitor crd.
The chart keeps it's default behavior with the annotations.

Regards,