### PR TITLE
Match filename to deployment.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ gcloud projects add-iam-policy-binding $project_id \
     --role=projects/${project_id}/roles/preemptible_killer
 $ gcloud iam --project=$project_id service-accounts keys create \
     --iam-account $service_account_email \
-    google_service_account.json
+    google-service-account.json
 ```
 
 ## Installation


### PR DESCRIPTION
Match filename of google service account in the filename saved to the deployment manifest. 
Ref https://github.com/estafette/estafette-gke-preemptible-killer/blob/main/manifests/deployment.yaml#L23 
`google_service_account.json` vs `google-service-account.json`