### PR TITLE
fix: add pods/eviction creation rights

### DIFF
--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -19,6 +19,11 @@ rules:
   - delete
   - get
   - list
+- apiGroups: [""] # "" indicates the core API group
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
to avoid it:
```
<nil> ERR failed to evict pod kube-state-metrics-objects-66c4cf5446-7nc5f error="pods \"kube-state-metrics-objects-66c4cf5446-7nc5f\" is forbidden: User \"system:serviceaccount:default:preemptible-killer\" cannot create resource \"pods/eviction\" in API group \"\" in the namespace \"foobar\""
```