### PR TITLE
Remove beta from rbac

### DIFF
--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: preemptible-killer
@@ -20,7 +20,7 @@ rules:
   - get
   - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: preemptible-killer


### PR DESCRIPTION
RBAC has been out of beta sine 1.8. Removed in 1.22. Replaced with `rbac.authorization.k8s.io/v1`.