### PR TITLE
Add support for spot instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You can either use environment variables or flags to configure the following set
 | METRICS_LISTEN_ADDRESS | --metrics-listen-address | :9001    | The address to listen on for Prometheus metrics requests
 | METRICS_PATH           | --metrics-path           | /metrics | The path to listen for Prometheus metrics requests
 | WHITELIST_HOURS        | --whitelist-hours (-w)   |          | List of UTC time intervals in the form of `09:00 - 12:00, 13:00 - 18:00` in which deletion is allowed and preferred
+| MONITOR_SPOT_INSTANCES | --montor-spot-instances  |          | Monitor and manage spot instances instead of preemptible
 
 ### Create a Google Service Account
 

--- a/kubernetes_client.go
+++ b/kubernetes_client.go
@@ -59,8 +59,12 @@ func (c *kubernetesClient) GetProjectIdAndZoneFromNode(ctx context.Context, node
 // GetPreemptibleNodes return a list of preemptible node
 func (c *kubernetesClient) GetPreemptibleNodes(ctx context.Context, filters map[string]string) (nodes *v1.NodeList, err error) {
 
-	labelSelector := labels.Set{
-		"cloud.google.com/gke-preemptible": "true",
+	labelSelector := labels.Set{}
+
+	if *monitorSpotInstances {
+		labelSelector["cloud.google.com/gke-spot"] = "true"
+	} else {
+		labelSelector["cloud.google.com/gke-preemptible"] = "true"
 	}
 
 	for key, value := range filters {

--- a/main.go
+++ b/main.go
@@ -60,6 +60,9 @@ var (
 			Default("").
 			Short('w').
 			String()
+	monitorSpotInstances = kingpin.Flag("montor-spot-instances", "Monitor and manage spot instances instead of preemptible").
+			Envar("MONITOR_SPOT_INSTANCES").
+			Bool()
 
 	// define prometheus counter
 	nodeTotals = prometheus.NewCounterVec(


### PR DESCRIPTION
GCP recently added spot instances. They have a different set of labels and this prevents `gke-preemptible-killer` from selecting the right nodes. This PR adds a flag that allows filtering for spot instances.

Fixes: #101 